### PR TITLE
updated with a few fixes and deletions

### DIFF
--- a/deployment.template.json
+++ b/deployment.template.json
@@ -36,17 +36,17 @@
           }
         },
         "modules": {
-          "tempSensor": {
+          "testApp": {
             "version": "1.0",
             "type": "docker",
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
+              "image": "${MODULES.TestApp.amd64}",
               "createOptions": ""
             }
           },
-          "RedisEdge": {
+          "redisedge": {
             "version": "0.8",
             "type": "docker",
             "status": "running",

--- a/modules/RedisEdge/module.json
+++ b/modules/RedisEdge/module.json
@@ -2,7 +2,7 @@
     "$schema-version": "0.0.1",
     "description": "",
     "image": {
-        "repository": "myiotregistery.azurecr.io/redis-edge",
+        "repository": "$CONTAINER_REGISTRY_ADDRESS/redisedge",
         "tag": {
             "version": "0.8",
             "platforms": {

--- a/modules/TestApp/main.py
+++ b/modules/TestApp/main.py
@@ -65,8 +65,7 @@ def module_twin_callback(update_state, payload, user_context):
         if UPDATE_REDIS == "yes":
             #write values to Redis DB
             r = redis.Redis(host='redisedge', port=6379)
-            #r.set('foo', 'bar') //commenting out for testing of streams
-
+            
             #test redis streams
             xaddstream = 'XADD frameStream * '
             xaddkey = 'frame' #could combine with above - leaving as is for now

--- a/modules/TestApp/main.py
+++ b/modules/TestApp/main.py
@@ -55,7 +55,7 @@ def receive_message_callback(message, hubManager):
     hubManager.forward_event_to_output("output1", message, 0)
     return IoTHubMessageDispositionResult.ACCEPTED
 
-# module_twin_callback is invoked when the module twin's desired properties are updated.
+# module_twin_callback is invoked when the module twin's desired properties are updated. 
 def module_twin_callback(update_state, payload, user_context):
     global TWIN_CALLBACKS
     print ( "\nTwin callback called with:\nupdateStatus = %s\npayload = %s\ncontext = %s" % (update_state, payload, user_context) )

--- a/modules/TestApp/module.json
+++ b/modules/TestApp/module.json
@@ -2,7 +2,7 @@
     "$schema-version": "0.0.1",
     "description": "",
     "image": {
-        "repository": "myiotregistery.azurecr.io/test-app",
+        "repository": "$CONTAINER_REGISTRY_ADDRESS/test-app",
         "tag": {
             "version": "0.0.1",
             "platforms": {


### PR DESCRIPTION
Hey Andre, I removed the "tempsensor" module from the solutions since we don't need it. I also added a variable into the deployment json for the testApp and RedisEdge modules so that future pulls don't have issues with the wrong container registry name.

Finally, I renamed the module from: RedisEdge to redisedge in the deployment.template.json, only because the code was expecting the of the module to be all lowercase. We can make the name whatever we wish it to be, but they do have to match so that the testApp module can resolve the name properly when trying to connect to it. Everything works as is right now.

I'm going to use this version of the Redis module to update the AI demo as I had some ideas over the weekend I wanted to try as far as adding a demo app on top of it.
